### PR TITLE
Implement .env support and hot-reloading

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,8 @@
 {:paths ["src" "resources"]
 
  :deps
- {org.clojure/clojure {:mvn/version "1.11.1"}}
+ {org.clojure/clojure {:mvn/version "1.11.1"}
+  com.lambdaisland/dotenv {:mvn/version "0.1.1"}}
 
  :aliases
  {:dev

--- a/src/lambdaisland/launchpad/deps.clj
+++ b/src/lambdaisland/launchpad/deps.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.edn :as edn]
    [clojure.java.io :as io]
-   [clojure.tools.deps.alpha :as deps]))
+   [clojure.tools.deps.alpha :as deps]
+   [lambdaisland.classpath.watch-deps :as watch-deps]))
 
 (defn basis [opts]
   (let [deps-local-file (io/file "deps.local.edn")
@@ -12,3 +13,21 @@
     (deps/create-basis (-> opts
                            (update :aliases concat (:launchpad/aliases deps-local))
                            (assoc :extra extra-deps)))))
+
+(defn watch-handlers [opts]
+  (let [basis (basis opts)
+        deps-paths (cond-> [(watch-deps/path watch-deps/process-root-path "deps.edn")]
+                     (:include-local-roots? opts)
+                     (into (->> (vals (:libs basis))
+                                (keep :local/root)
+                                (map watch-deps/canonical-path)
+                                (map #(watch-deps/path % "deps.edn"))))
+                     (string? (:extra opts))
+                     (conj (watch-deps/canonical-path (:extra opts)))
+                     :always
+                     (concat (:watch-paths opts)))
+        handler (partial #'watch-deps/on-event deps-paths opts)]
+    (into {}
+          (map (fn [p]
+                 [(str p) handler]))
+          deps-paths)))

--- a/src/lambdaisland/launchpad/env.clj
+++ b/src/lambdaisland/launchpad/env.clj
@@ -1,0 +1,87 @@
+(ns lambdaisland.launchpad.env
+  "Make environment variables modifiable from within Java, and use that to watch a
+  .env file for changes, and hot reload them.
+
+  This is *very* dirty, it uses reflection to get at various private bits of
+  Java, it relies on implementation details of OpenJDK, and it requires breaking
+  module isolation (the process has to start with
+  `--add-opens=java.base/java.lang=ALL-UNNAMED`
+  `--add-opens=java.base/java.util=ALL-UNNAMED`). We also rely on jnr-posix to
+  get to the underlying setenv system call, for good measure.
+
+  But hey it works!"
+  (:require [lambdaisland.dotenv :as dotenv])
+  (:import (java.nio.file Path Files LinkOption)))
+
+(set! *warn-on-reflection* true)
+
+(defn accessible-field ^java.lang.reflect.Field [^Class klz field]
+  (doto (.getDeclaredField klz field)
+    (.setAccessible true)))
+
+(defn get-static [field]
+  (let [klz (Class/forName (namespace field))]
+    (.get (accessible-field klz
+                            (name field)) klz)))
+
+(defn get-field [^Object instance field]
+  (.get (accessible-field (.getClass instance) (str field)) instance))
+
+(defn set-field! [klz field obj val]
+  (.set (accessible-field klz field) obj val))
+
+(defn set-static! [klz field val]
+  (set-field! klz field klz val))
+
+(def ^java.util.Map theEnvironment
+  (get-static 'java.lang.ProcessEnvironment/theEnvironment))
+
+(def ^java.lang.ProcessEnvironment$StringEnvironment theUnmodifiableEnvironment
+  (get-field (get-static 'java.lang.ProcessEnvironment/theUnmodifiableEnvironment) 'm))
+
+(def ^jnr.posix.POSIX posix (jnr.posix.POSIXFactory/getPOSIX))
+
+(defn new-value [^String str]
+  (assert (= -1 (.indexOf str "\u0000")))
+  (let [^java.lang.reflect.Constructor init
+        (first (.getDeclaredConstructors java.lang.ProcessEnvironment$Value))]
+    (.setAccessible init true)
+    (.newInstance init (into-array Object ["XXX" (.getBytes "XXX")]))))
+
+(defn new-variable [^String str]
+  (assert (and (= -1 (.indexOf str "="))
+               (= -1 (.indexOf str "\u0000"))))
+  (let [^java.lang.reflect.Constructor init
+        (first (.getDeclaredConstructors java.lang.ProcessEnvironment$Value))]
+    (.setAccessible init true)
+    (.newInstance init (into-array Object ["XXX" (.getBytes "XXX")]))))
+
+(defn setenv
+  ([env]
+   (run! (fn [[k v]] (setenv k v)) env))
+  ([^String var ^String val]
+   ;; This one is used by ProcessBuilder
+   (.put theEnvironment (new-value var) (new-variable val))
+   ;; This one is used by System/getenv
+   (.put theUnmodifiableEnvironment var val)
+   ;; Also change the actual OS environment for the process
+   (.setenv posix var val 1)))
+
+(defn exists?
+  "Does the given path exist."
+  [path]
+  (Files/exists path (into-array LinkOption [])))
+
+(defn dotenv-watch-handler [paths]
+  (let [paths (map #(Path/of % (into-array String [])) paths)]
+    (fn [_]
+      (setenv
+       (apply merge
+              (map #(when (exists? %)
+                      (dotenv/parse-dotenv (Files/readString %)))
+                   paths))))))
+
+(defn watch-handlers []
+  (let [h (dotenv-watch-handler [".env" ".env.local"])]
+    {".env" h
+     ".env.local" h}))

--- a/src/lambdaisland/launchpad/watcher.clj
+++ b/src/lambdaisland/launchpad/watcher.clj
@@ -1,0 +1,61 @@
+(ns lambdaisland.launchpad.watcher
+  "Higher level wrapper around Beholder.
+
+  Beholder watches directories, not files. We want to watch specific files in
+  specific directories. This can be done with [[watch!]], which will start the
+  minimum number of watchers to cover all directories, and will dispatch to the
+  right handler based on the changed file."
+  (:require [nextjournal.beholder :as beholder])
+  (:import java.util.regex.Pattern
+           java.nio.file.LinkOption
+           java.nio.file.Files
+           java.nio.file.Paths
+           java.nio.file.Path))
+
+(defonce watchers (atom nil))
+
+(defn path ^Path [root & args]
+  (if (and (instance? Path root) (not (seq args)))
+    root
+    (Paths/get (str root) (into-array String args))))
+
+(defn canonical-path [p]
+  (.toRealPath (path p) (into-array LinkOption [])))
+
+(defn parent-path [p]
+  (.getParent (path p)))
+
+(require 'clojure.pprint)
+
+(defn watch!
+  "Watch a number of files, takes a map from filename (string) to
+  handler (receives a map with `:type` and `:path`, as with Beholder)."
+  [file->handler]
+  (let [file->handler (update-keys file->handler canonical-path)
+        directories (distinct (map parent-path (keys file->handler)))
+        ;; in case of nested directories, only watch the top-most one
+        directories (remove (fn [d]
+                              (some #(and (not= d %)
+                                          (.startsWith d %)) directories))
+                            directories)]
+    (swap! watchers
+           (fn [w]
+             (when w
+               (run! beholder/stop w))
+             (doall
+              (for [dir directories]
+                (beholder/watch
+                 (fn [{:keys [type path] :as event}]
+                   (when-let [f (get file->handler path)]
+                     (try
+                       (f event)
+                       (catch Exception e
+                         (prn e)))))
+                 (str dir))))))))
+
+(comment
+  (watch!
+   {"/home/arne/Gaiwan/slack-widgets/deps.edn" prn
+    "/home/arne/Gaiwan/slack-widgets/.env" prn
+    "/home/arne/Gaiwan/slack-widgets/.envx" prn
+    "/home/arne/Gaiwan/slack-widgets/backend/deps.edn" prn}))


### PR DESCRIPTION
Load environment variables from .env and .env.local, and also watch these files for changes.

Java does not normally allow you to change the environment variables of the running JVM, and we go through some serious shenanigans to support it.

We also unified the watching of deps.edn and .env so we don't have to start so many different beholder watchers. Other launchpad extensions can plug in to this mechanism as well to watch additional files.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
