### PR TITLE
✨ Allow connection to specific shadow-ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ configure launchpad.
  :launchpad/shadow-build-ids [] ; which shadow builds to start, although it may
                                 ; be preferable to configure this as part of
                                 ; specific aliases in your main deps.edn
+ ;; which shadow builds to automatically connect to if `--emacs` flag is provided
+ :launchpad/shadow-connect-ids [] 
  }
 ```
 


### PR DESCRIPTION
This is for cases where you may need to start builds for multiple
shadow-ids, but only need emacs to connect to some of those builds

```edn
 :launchpad/shadow-connect-ids [:sidebar]
```

Maybe a better name is `emacs-connect-shadow-ids`? 🤔 