### PR TITLE
Fix the launchpad version loaded at runtime by bb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+- Update the launchpad version loaded at runtime
+
 ## Changed
 
 # 0.31.142-alpha (2024-07-15 / 35813ab)

--- a/resources/launchpad/deps.edn
+++ b/resources/launchpad/deps.edn
@@ -2,7 +2,7 @@
 ;; things to use. We keep it in deps.edn format so antq can automatically
 ;; upgrade versions.
 {:deps
- {com.lambdaisland/launchpad    {:mvn/version "0.28.129-alpha"}
+ {com.lambdaisland/launchpad    {:mvn/version "0.31.142-alpha"}
   com.lambdaisland/classpath    {:mvn/version "0.5.48"}
   com.github.jnr/jnr-posix      {:mvn/version "3.1.19"}
   thheller/shadow-cljs          {:mvn/version "2.28.3"}


### PR DESCRIPTION
Currently the launchpad version being loaded by `bb` and the launchpad version used to inject the dependency are different. I need to look into this more, but this currently fixes my issue.

A cleaner solution would be to find the currently loaded launchpad and use that as default?