### PR TITLE
Correct dotenv watch semantics and refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@
 ## Fixed
 
 - Add an `:nrepl.middleware/descriptor` to silence the warning
+- Correct dotenv watch semantics. No matter the initial state we fix the behavior to achieve:
+
+  | .env  | .env.local | Values From  |
+  | ----- |----------- | ------------ |
+  | ✅    | ✅         | `.env.local` |
+  | ✅    | ❌         | `.env`       |
+  | ❌    | ✅         | `.env.local` |
+  | ❌    | ❌         | latest state |
+
+  The last line means we currently do not keep track and therefore cannot remove already set environment variables.
 
 # 0.36.159-alpha (2025-02-09 / eafa135)
 

--- a/src/lambdaisland/launchpad/env.clj
+++ b/src/lambdaisland/launchpad/env.clj
@@ -1,88 +1,27 @@
 (ns lambdaisland.launchpad.env
-  "Make environment variables modifiable from within Java, and use that to watch a
-  .env file for changes, and hot reload them.
-
-  This is *very* dirty, it uses reflection to get at various private bits of
-  Java, it relies on implementation details of OpenJDK, and it requires breaking
-  module isolation (the process has to start with
-  `--add-opens=java.base/java.lang=ALL-UNNAMED`
-  `--add-opens=java.base/java.util=ALL-UNNAMED`). We also rely on jnr-posix to
-  get to the underlying setenv system call, for good measure.
-
-  But hey it works!"
-  (:require [lambdaisland.dotenv :as dotenv]
-            [lambdaisland.classpath.watch-deps :as watch-deps])
-  (:import (java.nio.file Path Files LinkOption)))
-
-(set! *warn-on-reflection* true)
-
-(defn accessible-field ^java.lang.reflect.Field [^Class klz field]
-  (doto (.getDeclaredField klz field)
-    (.setAccessible true)))
-
-(defn get-static [field]
-  (let [klz (Class/forName (namespace field))]
-    (.get (accessible-field klz
-                            (name field)) klz)))
-
-(defn get-field [^Object instance field]
-  (.get (accessible-field (.getClass instance) (str field)) instance))
-
-(defn set-field! [klz field obj val]
-  (.set (accessible-field klz field) obj val))
-
-(defn set-static! [klz field val]
-  (set-field! klz field klz val))
-
-(def ^java.util.Map theEnvironment
-  (get-static 'java.lang.ProcessEnvironment/theEnvironment))
-
-(def ^java.lang.ProcessEnvironment$StringEnvironment theUnmodifiableEnvironment
-  (get-field (get-static 'java.lang.ProcessEnvironment/theUnmodifiableEnvironment) 'm))
-
-(def ^jnr.posix.POSIX posix (jnr.posix.POSIXFactory/getPOSIX))
-
-(defn new-value [^String str]
-  (assert (= -1 (.indexOf str "\u0000")))
-  (let [^java.lang.reflect.Constructor init
-        (first (.getDeclaredConstructors java.lang.ProcessEnvironment$Value))]
-    (.setAccessible init true)
-    (.newInstance init (into-array Object ["XXX" (.getBytes "XXX")]))))
-
-(defn new-variable [^String str]
-  (assert (and (= -1 (.indexOf str "="))
-               (= -1 (.indexOf str "\u0000"))))
-  (let [^java.lang.reflect.Constructor init
-        (first (.getDeclaredConstructors java.lang.ProcessEnvironment$Variable))]
-    (.setAccessible init true)
-    (.newInstance init (into-array Object ["XXX" (.getBytes "XXX")]))))
-
-(defn setenv
-  ([env]
-   (run! (fn [[k v]] (setenv k v)) env))
-  ([^String var ^String val]
-   ;; This one is used by ProcessBuilder
-   (.put theEnvironment (new-variable var) (new-value val))
-   ;; This one is used by System/getenv
-   (.put theUnmodifiableEnvironment var val)
-   ;; Also change the actual OS environment for the process
-   (.setenv posix var val 1)))
+  (:require [lambdaisland.dotenv :as dotenv])
+  (:import (java.nio.file Files LinkOption Path)))
 
 (defn exists?
   "Does the given path exist."
   [path]
-  (Files/exists (watch-deps/path path) (into-array LinkOption [])))
+  (Files/exists path (into-array LinkOption [])))
 
-(defn dotenv-watch-handler [paths]
-  (let [paths (map #(Path/of % (into-array String [])) paths)]
-    (fn [_]
-      (setenv
-       (apply merge
-              (map #(when (exists? %)
-                      (dotenv/parse-dotenv (Files/readString %)))
-                   paths))))))
+(defn ->path
+  [^String path]
+  (Path/of path (into-array String [])))
 
-(defn watch-handlers []
-  (let [h (dotenv-watch-handler [".env" ".env.local"])]
-    {".env" h
-     ".env.local" h}))
+(defn canonical-path
+  [^Path path]
+  (.toRealPath path (into-array LinkOption [])))
+
+(def ^{:doc "The list of dotenv paths to watch.
+
+Order counts as we use merge semantics when reading them in."}
+  watch-paths [".env" ".env.local"])
+
+(defn parse-dotenv
+  [^Path path]
+  (when (.exists (.toFile path))
+    (-> (Files/readString path)
+        (dotenv/parse-dotenv))))

--- a/src/lambdaisland/launchpad/env/hacks.clj
+++ b/src/lambdaisland/launchpad/env/hacks.clj
@@ -1,0 +1,88 @@
+(ns lambdaisland.launchpad.env.hacks
+  "Make environment variables modifiable from within Java.
+
+  This is *very* dirty, it uses reflection to get at various private bits of
+  Java, it relies on implementation details of OpenJDK, and it requires breaking
+  module isolation (the process has to start with
+  `--add-opens=java.base/java.lang=ALL-UNNAMED`
+  `--add-opens=java.base/java.util=ALL-UNNAMED`). We also rely on jnr-posix to
+  get to the underlying setenv system call, for good measure.
+
+  But hey it works!"
+  (:require [lambdaisland.classpath.watch-deps :as watch-deps])
+  (:import (java.nio.file Path)))
+
+(set! *warn-on-reflection* true)
+
+(defn accessible-field ^java.lang.reflect.Field [^Class klz field]
+  (doto (.getDeclaredField klz field)
+    (.setAccessible true)))
+
+(defn get-static [field]
+  (let [klz (Class/forName (namespace field))]
+    (.get (accessible-field klz
+                            (name field)) klz)))
+
+(defn get-field [^Object instance field]
+  (.get (accessible-field (.getClass instance) (str field)) instance))
+
+(defn set-field! [klz field obj val]
+  (.set (accessible-field klz field) obj val))
+
+(defn set-static! [klz field val]
+  (set-field! klz field klz val))
+
+(def ^java.util.Map theEnvironment
+  (get-static 'java.lang.ProcessEnvironment/theEnvironment))
+
+(def ^java.lang.ProcessEnvironment$StringEnvironment theUnmodifiableEnvironment
+  (get-field (get-static 'java.lang.ProcessEnvironment/theUnmodifiableEnvironment) 'm))
+
+(def ^jnr.posix.POSIX posix (jnr.posix.POSIXFactory/getPOSIX))
+
+(defn new-value [^String str]
+  (assert (= -1 (.indexOf str "\u0000")))
+  (let [^java.lang.reflect.Constructor init
+        (first (.getDeclaredConstructors java.lang.ProcessEnvironment$Value))]
+    (.setAccessible init true)
+    (.newInstance init (into-array Object ["XXX" (.getBytes "XXX")]))))
+
+(defn new-variable [^String str]
+  (assert (and (= -1 (.indexOf str "="))
+               (= -1 (.indexOf str "\u0000"))))
+  (let [^java.lang.reflect.Constructor init
+        (first (.getDeclaredConstructors java.lang.ProcessEnvironment$Variable))]
+    (.setAccessible init true)
+    (.newInstance init (into-array Object ["XXX" (.getBytes "XXX")]))))
+
+(defn setenv
+  ([env]
+   (run! (fn [[k v]] (setenv k v)) env))
+  ([^String var ^String val]
+   ;; This one is used by ProcessBuilder
+   (.put theEnvironment (new-variable var) (new-value val))
+   ;; This one is used by System/getenv
+   (.put theUnmodifiableEnvironment var val)
+   ;; Also change the actual OS environment for the process
+   (.setenv posix var val 1)))
+
+(defn dotenv-watch-handler
+  [{:keys [watch-paths parse-fn]}]
+  (let [parse-fn (requiring-resolve parse-fn)]
+    (fn [e]
+      (let [{:keys [type _]} e]
+        (when (contains? #{:modify :create :delete} type)
+          (doseq [path watch-paths]
+            (println "[watch-dotenv] ✨ Reloading"
+                     (str (.relativize ^Path (watch-deps/canonical-path ".") path))
+                     "✨"))
+          ;; We always reload everything so that we can preserve merge semantics.
+          (setenv (apply merge (map parse-fn watch-paths))))))))
+
+(defn watch-handlers [opts]
+  (let [{:keys [watch-paths]} opts
+        handler (dotenv-watch-handler opts)]
+    (into {}
+          (map (fn [p]
+                 [(str p) handler]))
+          watch-paths)))


### PR DESCRIPTION
When using the dotenv functionality I have noticed that we were not correctly handling file creation and deletion and decided to fix it.

This patch makes sure that we do the following no matter the initial state (aka, it does not matter if the files are missing when you launch the pad):

  | .env  | .env.local | Values From  |
  | ----- |----------- | ------------ |
  | ✅    | ✅         | `.env.local` |
  | ✅    | ❌         | `.env`       |
  | ❌    | ✅         | `.env.local` |
  | ❌    | ❌         | latest state |

The last line means we currently do not keep track and therefore cannot remove already set environment variables.

The patch also refactors the code a bit to remove code duplication:

  * `lamdbaisland.launchpad.env` is babashka-compatible and can is required into `lambdaistland.launchpad` in order to populate `:env`.

  * `lamdbaisland.launchpad.env.hacks`: is now the one evaluated by the watcher, uses `com.lamdbaisland.classpath` and contains the "nitty-gritty" details.
