### PR TITLE
Make initial summary print aliases with namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@
 
 ## Changed
 
+- Make initial summary print aliases with namespace.
+
+  Before:
+  ```
+  Aliases: dev, cider, zprint, local
+  ```
+  After:
+  ```
+  Aliases: :dev, :home/cider, :home/zprint, :mine/local
+  ```
+
 # 0.42.182-alpha (2025-03-01 / 50cc172)
 
 ## Fixed

--- a/src/lambdaisland/launchpad.clj
+++ b/src/lambdaisland/launchpad.clj
@@ -473,7 +473,7 @@
                (str/join ", " (map (comp (partial ansi-fg :magenta) name key) opts))))
     (when (seq aliases)
       (println (ansi-fg :green "Aliases:")
-               (str/join ", " (map (comp (partial ansi-fg :magenta) name) aliases)))))
+               (str/join ", " (map (comp (partial ansi-fg :magenta) str) aliases)))))
   ;; #_(apply println "Java flags: " (:java-args ctx))
   ;; (println "\nMiddleware: " )
   ;; (doseq [a (:middleware ctx)] (println "-" a))


### PR DESCRIPTION
They were printed without the namespace but the namespace can be used to indicate where the alias comes from and it is important to see in the summary. This patch fixes that by changing `name` to `str`.

Before:
```
Aliases: dev, cider, zprint, local
```
After:
```
Aliases: :dev, :home/cider, :home/zprint, :mine/local
```


