### PR TITLE
Introduce :launchpad/jvm-opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Add `--no-prefix` or `{:launchpad/options {:prefix false}}` to hide the
   start-of-line per-process prefix in the output
+- Support `:launchpad/jvm-opts`: the option is, same as the built-in
+  one, used for injecting JVM options to the clojure process.
 
 ## Fixed
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ configure launchpad.
  :launchpad/main-opts ["--emacs"] ; additional CLI flags, so you can encode your
                                   ; own preferences
 
+ :launchpad/jvm-opts ["-XX:-OmitStackTraceInFastThrow"] ; additional JVM options
+
  ;; takes options as a map and merges it into the `ctx`
  :launchpad/options {:portal true
                      :nrepl-port 1234}

--- a/src/lambdaisland/launchpad.clj
+++ b/src/lambdaisland/launchpad.clj
@@ -251,6 +251,9 @@
         (update :main-opts (fnil into []) (concat
                                            (:launchpad/main-opts deps-system)
                                            (:launchpad/main-opts deps-local)))
+        (update :java-args (fnil into []) (concat
+                                           (:launchpad/jvm-opts deps-system)
+                                           (:launchpad/jvm-opts deps-local)))
         (merge
          (:launchpad/options deps-system)
          (:launchpad/options deps-local))


### PR DESCRIPTION
Make sure we populate the internal :java-args from the above-mentioned key, therefore allowing `deps.local.edn` to contain things that differ from `deps.edn`.

Note that there is naming discrepancy as this patch sticks with the official key - `:jvm-opts` rather than the internal name.

The behavior of appending to existing `:jvm-opts`, in order, has been preserved as per the `tools.deps` built-in.