### PR TITLE
Introduce --execute option and functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 - Add `--no-prefix` or `{:launchpad/options {:prefix false}}` to hide the
   start-of-line per-process prefix in the output
+- Introduce `--execute` (or `{:launchpad/options {:execute false}}`) and
+  functionality that can launch the first configured `:exec-fn` (and
+  relative `:exec-args`).
 
 ## Fixed
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,34 @@ Most of the time you want to add extra steps either right before, or right after
            launchpad/start-process]
           launchpad/after-steps)})
 ```
+
+## Launch `:exec-fn` in aliases
+
+Launchpad can also call the first `:exec-fn` function (and relative `:exec-args`) it finds in its aggregated aliases.
+
+This behavior is enabled by adding `--execute` to the command line.
+
+> [!TIP]
+> The `Aliases:` line in the summary shows the ordered list of processed aliases. Only the first `:exec-fn` is used. 
+
+For example, you can configure an `:mcp` alias (from bhauman/clojure-mcp) within `deps.local.edn` like this:
+
+```clojure
+:aliases {:mcp {:extra-deps {org.slf4j/slf4j-nop {:mvn/version "2.0.16"}
+                             com.bhauman/clojure-mcp {:local/root "/path/to/clojure-mcp"}}
+                :exec-fn clojure-mcp.main/start-mcp-server
+                :exec-args {:port 7888}}}
+...
+```
+
+and launchpad will be able to call `clojure-mcp.main/start-mcp-server` this way:
+
+```
+$ launchpad --execute mcp
+```
+
+Note that this is a completely new code path and neither start nrepl nor hooks up the hot reloading facilities.
+
 ## Praise from Users
 
 "This looks like a much easier way to get a new project up and running in a consistent and predictable manner where there is less likelihood of steps being missed or being different enough to cause confusion or additional cognitive load when switching projects. As you point out, also great for getting a team all working in a consistent configuration." -- Tim Cross, @theophilusx1


### PR DESCRIPTION
This patch adds more superpowers to launchpad: it can now launch the first configured `:exec-fn` (and relative `:exec-args`).

This behavior is enabled by adding `--execute` to the command line.

It does it by introducing a brand new `execute-steps` var containing, among the others, the `exec-fn-eval-forms` step - the logic for appending the correct `:eval-forms`.

Note that this is a completely new code path and neither start nrepl nor hooks up the hot reloading facilities.

An example, you can configure an mcp alias (from bhauman/clojure-mcp)
within `deps.local.edn` like this:

```clojure
:aliases {:mcp {:extra-deps {org.slf4j/slf4j-nop {:mvn/version "2.0.16"}
                             com.bhauman/clojure-mcp {:local/root "/path/to/clojure-mcp"}}
                :exec-fn clojure-mcp.main/start-mcp-server
                :exec-args {:port 7888}}}
...
```

and launchpad will be able to call `clojure-mcp.main/start-mcp-server`
this way:

```
$ launchpad --execute mcp
```

Note that this is a completely new code path and neither start nrepl nor hooks up the hot reloading facilities.
