### PR TITLE
fix: preserve per-build :js-options in merged-shadow-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## Fixed
 
+- Preserve per-build `:js-options` in `merged-shadow-config`. Previously the
+  root project's builds had their `:js-options` unconditionally replaced with
+  `{}`, which clobbered settings like `:js-provider :external` and
+  `:external-index`. Now the root project's `:js-options` are left untouched,
+  and submodule builds get `:js-package-dirs` merged into their existing
+  `:js-options` rather than replacing them.
+
 ## Changed
 
 # 0.47.210-alpha (2026-03-02 / 54388ed)

--- a/src/lambdaisland/launchpad/shadow.clj
+++ b/src/lambdaisland/launchpad/shadow.clj
@@ -96,11 +96,11 @@
                                      k
                                      (keyword module-name (name k)))]
                              [build-id
-                              (assoc (update-build-keys process-root module-root v)
-                                     :build-id build-id
-                                     :js-options (if (= "" module-path)
-                                                   {}
-                                                   {:js-package-dirs [(str module-path "/node_modules")]}))])))
+                              (cond-> (update-build-keys process-root module-root v)
+                                true
+                                (assoc :build-id build-id)
+                                (not= "" module-path)
+                                (update :js-options merge {:js-package-dirs [(str module-path "/node_modules")]}))])))
 
                     builds)))))
         (assoc :deps {})


### PR DESCRIPTION
<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
`merged-shadow-config` unconditionally replaces each build's `:js-options` with
`{}` for the root project or `{:js-package-dirs [...]}` for submodules. This
wipes out any per-build `:js-options` defined in `shadow-cljs.edn`.

This breaks projects that use `:js-provider :external` with `:external-index`,
because shadow-cljs never sees those options and falls back to the default
`:shadow` provider — silently skipping generation of the external index file.

## Fix

- **Root project:** Don't touch `:js-options` at all (there's nothing to add)
- **Submodules:** `merge` into existing `:js-options` instead of replacing,
  so `:js-package-dirs` is added while preserving existing keys

## Before

```clojure
:js-options (if (= "" module-path)
              {}
              {:js-package-dirs [(str module-path "/node_modules")]})
```

## After

```clojure
(cond-> ...
  (not= "" module-path)
  (update :js-options merge {:js-package-dirs [(str module-path "/node_modules")]}))
```

I also updated the CHANGELOG with the fix. Please let me know if anything else is needed. Thank you for this great project!