### PR TITLE
Fix handling of --vs-code flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+- Fix a regression in the handling of the `--vs-code` flag
+
 ## Changed
 
 # 0.48.215-alpha (2026-03-04 / 2094974)

--- a/src/lambdaisland/launchpad.clj
+++ b/src/lambdaisland/launchpad.clj
@@ -287,7 +287,7 @@
             :cider-connect (:emacs ctx)}
            (dissoc ctx :emacs))
     (some? (:vs-code ctx))
-    (merge {:cider-nrepl (:emacs ctx)}
+    (merge {:cider-nrepl (:vs-code ctx)}
            (dissoc ctx :vs-code))
     :else
     ctx))


### PR DESCRIPTION
The `--vs-code` flag no longer adds the `cider-nrepl` option, which seems to be because of a copy/paste bug.

PS. It was very nice to use launchpad to set up the local dev env for it :)