### PR TITLE
fix: Prevent overwriting `js-package-dirs` in shadow-cljs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Added
 
 ## Fixed
+- Preserve & relativize to JVM proc root the shadow-cljs  per-build
+  `[:js-options :js-package-dirs]`.
 
 ## Changed
 

--- a/src/lambdaisland/launchpad/shadow.clj
+++ b/src/lambdaisland/launchpad/shadow.clj
@@ -52,6 +52,18 @@
     (:output-to build)
     (update :output-to (partial relativize process-root module-root))))
 
+(defn update-js-package-dirs
+  "Fix a merged build's :js-package-dirs for shadow running from the JVM process root:
+  relativize declared dirs to that root, or default to the module's then root node_modules. "
+  [build process-root module-root module-path]
+  (update-in build [:js-options :js-package-dirs]
+             (fn [dirs]
+               ;; relativize declared js-package-dirs to JVM process root. Example:
+               ;; :js-package-dirs ["../../node_modules"]
+               (mapv (partial relativize process-root module-root)
+                     (or dirs
+                         [(str module-path "/node_modules")])))))
+
 (defn merged-shadow-config
   "Given multiple locations that contain a shadow-cljs.edn, merge them into a
   single config, where the path locations have been updated."
@@ -100,7 +112,7 @@
                                 true
                                 (assoc :build-id build-id)
                                 (not= "" module-path)
-                                (update :js-options merge {:js-package-dirs [(str module-path "/node_modules")]}))])))
+                                (update-js-package-dirs process-root module-root module-path))])))
 
                     builds)))))
         (assoc :deps {})


### PR DESCRIPTION
<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->

If the `shadow-cljs.edn` was declaring `js-package-dirs` , launchpad was overwriting them with the module local path. This was killing our monorepo support. 

```bash
/monorepo-root
  node_modules/
  packages/
     frontend/
        shadow-cljs.edn          <- shadow-target
```

shadow-cljs.edn
```clojure
{
 :builds {:app {:target :browser
               ....
                :js-options {:anon-fn-naming-policy :unmapped
                             :js-provider :external
                             :js-package-dirs ["node_modules" "../../node_modules"] ;; <- was being overwritten to just local package node_moduels
                             :external-index "target/index.js"}}
         ...

```

Made a fix, so that if the build was already declaring `js-package-dirs` just relativize those to JVM proc root and move on instead of overwriting.

This is needed for us as we are using pnpm. Some of the dependencies are symlinked in the node_modules from `packages/frontend` but pnpm doesn't symlink transitive deps, of which we use many, breaking our build when using launchpad. 

Took some investigation as to why direct shadow-cljs builds were passing but breaking through launchpad.

Let me know if I should change anything. I tried to respect the style as much as possible. 
